### PR TITLE
Added @wraps decorator to wrapped - it fixes a bug within non-named djan...

### DIFF
--- a/rolepermissions/decorators.py
+++ b/rolepermissions/decorators.py
@@ -1,3 +1,4 @@
+from functools import wraps
 
 from django.core.exceptions import PermissionDenied
 
@@ -7,6 +8,7 @@ from rolepermissions.verifications import has_role, has_permission
 
 def has_role_decorator(role):
     def request_decorator(dispatch):
+        @wraps(dispatch)
         def wrapper(request, *args, **kwargs):
             user = request.user
             if user.is_authenticated():
@@ -20,6 +22,7 @@ def has_role_decorator(role):
 
 def has_permission_decorator(permission_name):
     def request_decorator(dispatch):
+        @wraps(dispatch)
         def wrapper(request, *args, **kwargs):
             user = request.user
             if user.is_authenticated():


### PR DESCRIPTION
This minor change fixes a problem with non-named urls in Django. I've had this issue: 

http://stackoverflow.com/questions/28251431/applying-decorator-to-view-url-not-being-found-by-reverse

It doesn't brake the tests.