### PR TITLE
Django importlib warning fixed

### DIFF
--- a/rolepermissions/loader.py
+++ b/rolepermissions/loader.py
@@ -1,7 +1,7 @@
 from __future__ import unicode_literals
 
 from django.conf import settings
-from django.utils.importlib import import_module
+from importlib import import_module
 
 
 def load_roles_and_permissions():


### PR DESCRIPTION
Hi,

On Django 1.8, with Python 3.4, when django-role-permission, I got this warning message from the shell :  RemovedInDjango19Warning: django.utils.importlib will be removed in Django 1.9 .

By searching, I saw that's about the file laoder.py in rolepermissions floder. I fix it.

Regards,

Hodonou SOUNTON.


