### PR TITLE
Issue #39 - Added a settings 'ROLEPERMISSIONS_REDIRECT_TO_LOGIN' whic…

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -17,6 +17,7 @@ Contents:
    checkers
    functions
    utilities
+   settings
 
 
 Indices and tables

--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -1,0 +1,16 @@
+==========================
+Settings
+==========================
+
+
+Redirect to the login page
+==========================
+
+Instead of getting a Forbidden (403) error when the user has no permission, you can make the request be redirected to the login page.
+Add the following variable to your django ``settings.py``:
+
+``settings.py``
+
+.. code-block:: python
+
+    ROLEPERMISSIONS_REDIRECT_TO_LOGIN = True

--- a/rolepermissions/decorators.py
+++ b/rolepermissions/decorators.py
@@ -2,6 +2,8 @@ from __future__ import unicode_literals
 
 from functools import wraps
 
+from django.conf import settings
+from django.contrib.auth.views import redirect_to_login
 from django.core.exceptions import PermissionDenied
 
 from rolepermissions.roles import RolesManager
@@ -16,7 +18,8 @@ def has_role_decorator(role):
             if user.is_authenticated():
                 if has_role(user, role):
                     return dispatch(request, *args, **kwargs)
-
+            if hasattr(settings, 'ROLEPERMISSIONS_REDIRECT_TO_LOGIN'):
+                return redirect_to_login(request.get_full_path())
             raise PermissionDenied
         return wrapper
     return request_decorator
@@ -30,7 +33,8 @@ def has_permission_decorator(permission_name):
             if user.is_authenticated():
                 if has_permission(user, permission_name):
                     return dispatch(request, *args, **kwargs)
-
+            if hasattr(settings, 'ROLEPERMISSIONS_REDIRECT_TO_LOGIN'):
+                return redirect_to_login(request.get_full_path())
             raise PermissionDenied
         return wrapper
     return request_decorator


### PR DESCRIPTION
…h redirects to the login page rather than a 403 error. When this settings is missing, the default behavior is kept