### PR TITLE
Update tox for python 3.6 and Django 1.11

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -85,6 +85,7 @@ setup(
         'Programming Language :: Python :: 3.3',
         'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
+        'Programming Language :: Python :: 3.6',
     ],
     test_suite='rolepermissions.tests',
     tests_require=test_requirements

--- a/tox.ini
+++ b/tox.ini
@@ -1,9 +1,9 @@
 [tox]
 envlist =
-    py{27}-django{15,16,17,18,19,110},
+    py{27}-django{15,16,17,18,19,110,111},
     py{33,34}-django{17},
-    py{34,35}-django{18,19,110},
-    py{34,35}-djangolatest
+    py{34,35,36}-django{18,19,110,111},
+    py{34,35,36}-djangolatest
 
 [testenv]
 commands = python manage.py test
@@ -12,6 +12,7 @@ basepython =
     py33: python3.3
     py34: python3.4
     py35: python3.5
+    py36: python3.6
 
 deps =
     six
@@ -22,6 +23,7 @@ deps =
     django18: Django>=1.8.0,<1.9.0
     django19: Django>=1.9.0,<1.10.0
     django110: Django>=1.10.0,<1.11.0
+    django111: Django>=1.11.0,<1.12.0
     djangolatest: https://github.com/django/django/archive/master.tar.gz
 
 [testenv:py34-djangolatest]


### PR DESCRIPTION
Summary of tox test:
```
  py27-django15: commands succeeded
  py27-django16: commands succeeded
  py27-django17: commands succeeded
  py27-django18: commands succeeded
  py27-django19: commands succeeded
  py27-django110: commands succeeded
  py27-django111: commands succeeded
  py33-django17: commands succeeded
  py34-django17: commands succeeded
  py34-django18: commands succeeded
  py34-django19: commands succeeded
  py34-django110: commands succeeded
  py34-django111: commands succeeded
  py35-django18: commands succeeded
  py35-django19: commands succeeded
  py35-django110: commands succeeded
  py35-django111: commands succeeded
  py36-django18: commands succeeded
  py36-django19: commands succeeded
  py36-django110: commands succeeded
  py36-django111: commands succeeded
  py34-djangolatest: commands succeeded
  py35-djangolatest: commands succeeded
  py36-djangolatest: commands succeeded
  congratulations :)
```