### PR TITLE
[WIP] Prevent empty name attributes for Permission objects

### DIFF
--- a/rolepermissions/roles.py
+++ b/rolepermissions/roles.py
@@ -161,7 +161,7 @@ class AbstractUserRole(object):
         if len(permissions) != len(permission_names):
             for permission_name in permission_names:
                 permission, created = Permission.objects.get_or_create(
-                    content_type=user_ct, codename=permission_name)
+                    content_type=user_ct, codename=permission_name, name=permission_name)
                 if created:
                     permissions.append(permission)
 


### PR DESCRIPTION
Hi,

this is a fix for my observation in #66 

Setting the ```name``` attribute to the value of ```codename``` might not be the best solution, but at least I see what permission I'm assigning. 

![permission-name](https://user-images.githubusercontent.com/1652523/29498781-3929a9fe-8603-11e7-9faf-bca244e9e948.png)

This seems to work for me™ with Django 1.8.x and Python 3.5

Best,
Sebastian