### PR TITLE
Fixing duplicate queries in has_permission Method

### DIFF
--- a/rolepermissions/permissions.py
+++ b/rolepermissions/permissions.py
@@ -43,16 +43,9 @@ def available_perm_status(user):
     Get a boolean map of the permissions available to a user
     based on that user's roles.
     """
-    roles = get_user_roles(user)
     permission_hash = {}
-
-    for role in roles:
-        permission_names = role.permission_names_list()
-
-        for permission_name in permission_names:
-            permission_hash[permission_name] = get_permission(
-                permission_name) in user.user_permissions.all()
-
+    for perm in user.user_permissions.all():
+        permission_hash[(perm.name).lower().replace(" ", "_")] = True
     return permission_hash
 
 


### PR DESCRIPTION
Hello,

This pull request consist of correction for Issue [81](https://github.com/vintasoftware/django-role-permissions/issues/81)

Previous code looped in all the `available_permissions` for each role and returned a hashmap of all permissions irrespective if it is the permission parsed in `has_permission` or not. 

This fix corrected the issues of duplicate queries on my side :)

Please feel free to accept this PR if required.

Thank you

