### PR TITLE
Query performance improvement (Fix for #81)

### DIFF
--- a/rolepermissions/checkers.py
+++ b/rolepermissions/checkers.py
@@ -5,7 +5,7 @@ import inspect
 from rolepermissions.roles import (
     RolesManager, get_user_roles)
 from rolepermissions.permissions import (
-    PermissionsManager, available_perm_status)
+    PermissionsManager, available_perm_names)
 
 
 def has_role(user, roles):
@@ -33,8 +33,7 @@ def has_permission(user, permission_name):
     if user and user.is_superuser:
         return True
 
-    return available_perm_status(user).get(permission_name, False)
-
+    return permission_name in available_perm_names(user)
 
 def has_object_permission(checker_name, user, obj):
     """Check if a user has permission to perform an action on an object."""

--- a/rolepermissions/permissions.py
+++ b/rolepermissions/permissions.py
@@ -56,6 +56,20 @@ def available_perm_status(user):
     return permission_hash
 
 
+def available_perm_names(user):
+    """
+    Return a list of permissions codenames available to a user, based on that user's roles.
+      i.e., keys for all "True" permissions from available_perm_status(user):
+       Assert: set(available_perm_names(user)) == set(perm for perm,has_perm in available_perm_status(user) if has_perm)
+       Query efficient; especially when prefetch_related('group', 'user_permissions') on user object.
+       No side-effects; permissions are not created in DB as side-effect.
+    """
+    roles = get_user_roles(user)
+    perm_names = set(p for role in roles for p in role.permission_names_list())
+    return [p.codename for p in user.user_permissions.all() if p.codename in perm_names] \
+                                                                        if roles else []  # e.g., user == None
+
+
 def grant_permission(user, permission_name):
     """
     Grant a user a specified permission.

--- a/rolepermissions/roles.py
+++ b/rolepermissions/roles.py
@@ -200,9 +200,9 @@ def retrieve_role(role_name):
 def get_user_roles(user):
     """Get a list of a users's roles."""
     if user:
-        roles = user.groups.filter(
-            name__in=RolesManager.get_roles_names()).order_by("name")
-        return [RolesManager.retrieve_role(role.name) for role in roles]
+        groups = user.groups.all()   # Important! all() query may be cached on User with prefetch_related.
+        roles = (RolesManager.retrieve_role(group.name) for group in groups if group.name in RolesManager.get_roles_names())
+        return sorted(roles, key=lambda r: r.get_name() )
     else:
         return []
 

--- a/rolepermissions/tests/test_shortcuts.py
+++ b/rolepermissions/tests/test_shortcuts.py
@@ -12,7 +12,7 @@ from rolepermissions.roles import (
 )
 from rolepermissions.permissions import (
     grant_permission, revoke_permission,
-    available_perm_status)
+    available_perm_status, available_perm_names)
 from rolepermissions.checkers import has_permission
 from rolepermissions.exceptions import (
     RoleDoesNotExist, RolePermissionScopeException)
@@ -442,8 +442,10 @@ class GetUserRoleTests(TestCase):
         assign_role(user, ShoRole3)
 
         fetched_user = get_user_model().objects.get(pk=self.user.pk)
-        with self.assertNumQueries(1):
-            user_roles = get_user_roles(fetched_user)
+        N = 3
+        with self.assertNumQueries(N):  # One query (fetch roles) per call
+            for i in range(N):
+                user_roles = get_user_roles(fetched_user)
 
     def test_queries_with_prefetch(self):
         user = self.user
@@ -453,8 +455,10 @@ class GetUserRoleTests(TestCase):
         assign_role(user, ShoRole3)
 
         fetched_user = get_user_model().objects.prefetch_related('groups').get(pk=self.user.pk)
-        with self.assertNumQueries(0):
-            user_roles = get_user_roles(fetched_user)
+        N = 3
+        with self.assertNumQueries(0):  # all data required is cached with fetched_user
+            for i in range(N):
+                user_roles = get_user_roles(fetched_user)
 
     def tearDown(self):
         RolesManager._roles = {}
@@ -494,6 +498,51 @@ class AvailablePermStatusTests(TestCase):
 
         self.assertFalse(perm_hash['permission3'])
         self.assertFalse(perm_hash['permission4'])
+
+
+class AvailablePermNamesTests(TestCase):
+
+    def assert_available_perm_names_equals_available_perm_status(self):
+        perm_hash = available_perm_status(self.user)
+        perm_names = available_perm_names(self.user)
+
+        self.assertEqual( set(perm_names), set(p for p, has_perm in perm_hash.items() if has_perm) )
+
+    def setUp(self):
+        self.user = mommy.make(get_user_model())
+        self.user_role = ShoRole2.assign_role_to_user(self.user)
+
+    def test_permission_names(self):
+        self.assert_available_perm_names_equals_available_perm_status()
+
+    def test_permission_names_multiple_groups(self):
+        """
+        If a user has a permission in any role, that permission should show as True,
+        no matter what other roles dictate.
+        """
+        ShoRole1.assign_role_to_user(self.user)
+        ShoRole4.assign_role_to_user(self.user)
+
+        self.assert_available_perm_names_equals_available_perm_status()
+
+    def test_permission_names_after_modification(self):
+        revoke_permission(self.user, 'permission3')
+
+        self.assert_available_perm_names_equals_available_perm_status()
+
+    def test_queries_no_prefetch(self):
+        fetched_user = get_user_model().objects.get(pk=self.user.pk)
+        N = 3
+        with self.assertNumQueries(2 * N):  # Two query (fetch roles, fetch permissions) per call
+            for i in range(N):
+                perm_names = available_perm_names(fetched_user)
+
+    def test_queries_with_prefetch(self):
+        fetched_user = get_user_model().objects.prefetch_related('groups', 'user_permissions').get(pk=self.user.pk)
+        N = 3
+        with self.assertNumQueries(0):  # all data required is cached with fetched_user
+            for i in range(N):
+                perm_names = available_perm_names(fetched_user)
 
 
 class GrantPermissionTests(TestCase):

--- a/rolepermissions/tests/test_verifications.py
+++ b/rolepermissions/tests/test_verifications.py
@@ -103,6 +103,20 @@ class HasPermissionTests(TestCase):
     def test_none_user_param(self):
         self.assertFalse(has_permission(None, 'ver_role1'))
 
+    def test_queries_no_prefetch(self):
+        fetched_user = get_user_model().objects.get(pk=self.user.pk)
+        N = 3
+        with self.assertNumQueries(2 * N):  # Two query (fetch roles, fetch permissions) per call
+            for i in range(N):
+                has_permission(fetched_user, 'permission1')
+
+    def test_queries_with_prefetch(self):
+        fetched_user = get_user_model().objects.prefetch_related('groups', 'user_permissions').get(pk=self.user.pk)
+        N = 3
+        with self.assertNumQueries(0):  # all data required is cached with fetched_user
+            for i in range(N):
+                has_permission(fetched_user, 'permission1')
+
 
 class HasObjectPermissionTests(TestCase):
 


### PR DESCRIPTION
Resolves multiple redundant queries arising from `has_permission()` and `get_roles()`.
Allows client to use `prefetch_related()` to cache all group/permission data required on the user object passed in, resulting in no additional queries, regardless of how many permissions are checked.

Additional tests added for (1) new function and for query performance of above API functions.

_Undocumented API change_: `has_permission()` had a potential side-effect - an auth.Permission might be created and saved to DB.  That side-effect has been removed.  Seems unlikely anyone was relying on this, and can't think of any reason it would change any observable behaviour of API in any case.